### PR TITLE
create local database with docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  mongodb:
+    image: mongo
+    restart: always
+    ports:
+      - 27017:27017


### PR DESCRIPTION
Closes #26 
created local database for future project development.
Can be called upon by `docker compose up` in the terminal
